### PR TITLE
Merge os-info-calc-86 branch

### DIFF
--- a/java/info/rlwhitcomb/calc/CalcObjectVisitor.java
+++ b/java/info/rlwhitcomb/calc/CalcObjectVisitor.java
@@ -406,6 +406,7 @@
  *	    #81: Add directive to quote strings (or not).
  *	16-Nov-2021 (rlwhitcomb)
  *	    #87: Strip any quotes from incoming string argument values.
+ *	    #86: Change "versioninfo" to just "info" and add "os" and "java" parts.
  */
 package info.rlwhitcomb.calc;
 
@@ -688,13 +689,32 @@ public class CalcObjectVisitor extends CalcBaseVisitor<Object>
 	    SemanticVersion v = Environment.programVersion();
 	    ObjectScope version = new ObjectScope();
 
-	    version.setValue("major",      settings.ignoreNameCase, v.major);
-	    version.setValue("minor",      settings.ignoreNameCase, v.minor);
-	    version.setValue("patch",      settings.ignoreNameCase, v.patch);
-	    version.setValue("prerelease", settings.ignoreNameCase, v.getPreReleaseString());
-	    version.setValue("build",      settings.ignoreNameCase, v.getBuildMetaString());
+	    version.setValue("major",      false, v.major);
+	    version.setValue("minor",      false, v.minor);
+	    version.setValue("patch",      false, v.patch);
+	    version.setValue("prerelease", false, v.getPreReleaseString());
+	    version.setValue("build",      false, v.getBuildMetaString());
 
-	    PredefinedValue.define(globalScope, "versioninfo", version);
+	    ObjectScope os = new ObjectScope();
+
+	    os.setValue("platform", false, Environment.platform());
+	    os.setValue("version",  false, Environment.osVersion());
+	    os.setValue("id",       false, Environment.platformIdentifier());
+	    os.setValue("user",     false, Environment.currentUser());
+
+	    ObjectScope java = new ObjectScope();
+
+	    java.setValue("major",   false, Environment.javaMajorVersion());
+	    java.setValue("version", false, Environment.javaVersion());
+	    java.setValue("model",   false, Environment.dataModel());
+
+	    ObjectScope info = new ObjectScope();
+
+	    info.setValue("version", false, version);
+	    info.setValue("os",      false, os);
+	    info.setValue("java",    false, java);
+
+	    PredefinedValue.define(globalScope, "info", info);
 
 	    Supplier<Object> piSupplier = () -> {
 		BigDecimal d = piWorker.getPi();

--- a/java/info/rlwhitcomb/calc/calc_help.htmlpp
+++ b/java/info/rlwhitcomb/calc/calc_help.htmlpp
@@ -550,7 +550,7 @@ or
           <code>&#x2460;</code> .. <code>&#x2473;</code>, <code>&#x2474;</code> .. <code>&#x2487;</code>, <code>&#xFF10;</code> .. <code>&#xFF19;</code>, etc.<br>
           <code>today</code><br>
           <code>now</code><br>
-          <code>versioninfo</code><br>
+          <code>info</code><br>
           any string, binary, octal, hex, fraction, etc. constant</td>
       <td>the fundamental constants <code>&#x1D6D1;</code> and <code>e</code><br>
           the <code>boolean</code> values<br>
@@ -559,7 +559,7 @@ or
           other Unicode digit / number symbols<br>
           date value of the current date<br>
           time value of the current time<br>
-          current Calc version information<br>
+          current Calc information (version, os, java)<br>
           the constant value</td><td>N/A</td></tr>
     <tr><td>27</td><td><code>{</code> (&nbsp;<i>key:value pairs</i>&nbsp;) <code>}</code></td><td>define an object</td><td>left to right</td></tr>
     <tr><td>26</td><td><code>[</code> (&nbsp;<i>expr list</i>&nbsp;) <code>]</code><br><i>var</i> <code>[</code> <i>expr</i> <code>]</code> or <i>var</i>&nbsp;<code>&#x2080;</code> .. <code>&#x2089;</code></td><td>define an array,<br>or access elements of an array, string, or object</td><td>left to right</td></tr>

--- a/java/test/canons/e1_e2_e3.canon
+++ b/java/test/canons/e1_e2_e3.canon
@@ -1,6 +1,6 @@
 >Starting expression tests (suite 1).
 >
->versioninfo.major > 2 || (versioninfo.major == 2 && versioninfo.minor > 3) || (versioninfo.major == 2 && versioninfo.minor == 3 && versioninfo.patch >= 0) -> true
+>info.version.major > 2 || (info.version.major == 2 && info.version.minor > 4) || (info.version.major == 2 && info.version.minor == 4 && info.version.patch >= 11) -> true
 >Precision is now 50 digits.
 >52 + 27 -> 79
 >3.4 + 5 -> 8.4

--- a/java/test/files/demo
+++ b/java/test/files/demo
@@ -15,5 +15,5 @@ sqrt(2)/2
 :rad
 sin(𝛑/4)
 √ (𝛑 + ⅚ + 𝜋)
-versioninfo
+info.version
 

--- a/java/test/files/e1
+++ b/java/test/files/e1
@@ -5,8 +5,8 @@
 :echo
 
 # Simple version check ...
-# version 2.3.0 was first version where these checks would work
-versioninfo.major > 2 || (versioninfo.major == 2 && versioninfo.minor > 3) || (versioninfo.major == 2 && versioninfo.minor == 3 && versioninfo.patch >= 0)
+# version 2.3.0 was first version where these checks would work, and 2.4.11 is where versioninfo -> info.version
+info.version.major > 2 || (info.version.major == 2 && info.version.minor > 4) || (info.version.major == 2 && info.version.minor == 4 && info.version.patch >= 11)
 
 # Various simple expressions
 :decimal(50)

--- a/java/test/files/library.calc
+++ b/java/test/files/library.calc
@@ -204,7 +204,7 @@ def peek($s) = { _len = length($s._values) - 1; _len < 0 ? null : $s._values[_le
 /*
  * Construct a nice string form of the version information.
  */
-def versionstring = `Version ${versioninfo.major}.${versioninfo.minor}.${versioninfo.patch} build ${substr(versioninfo.build, 1)}${versioninfo.prerelease}`
+def versionstring = `Version ${info.version.major}.${info.version.minor}.${info.version.patch} build ${substr(info.version.build, 1)}${info.version.prerelease}`
 
 /*
  * Pad the given string to the given width with spaces on the right.

--- a/java/test/files/library.calc
+++ b/java/test/files/library.calc
@@ -215,4 +215,11 @@ def versionstring = `Version ${versioninfo.major}.${versioninfo.minor}.${version
  */
 define pad($s, $width) = { _s = $s ? $s : ''; fill(_s, ' ', length(_s), $width - length(_s)) }
 
+/*
+ * Exeute the "uuid" program to return a unique identifier.
+ *
+ * @return A unique identifier.
+ */
+define uuid() = {  trim(info.os.id == 'windows' ? exec('cmd', '/c', 'uuid.bat') : exec('uuid')) }
+
 :quiet pop

--- a/java/version.properties
+++ b/java/version.properties
@@ -13,7 +13,7 @@ Tree.title		= Directory Tree Utility
 Tree.version		= 1.2.8
 
 Calc.title		= Expression Calculator
-Calc.version		= 2.4.9
+Calc.version		= 2.4.11
 
 CompareFiles.title	= File/Directory Compare Utility
 CompareFiles.version	= 1.1.5


### PR DESCRIPTION
This change implements the "info" object in Calc, that now contains three independent pieces: "version", "os", and "java" that have the relevant bits of information from the Environment class methods. The "version" piece is exactly the same as "versioninfo" used to be, while "os" has "name", "version", and "id", and "java" has "major", "version", and "model" (32 or 64).
The merge of "trap-calc-exec-exceptions-85" should be done before this one, since the version for Calc increments each time.